### PR TITLE
Add Japanese case

### DIFF
--- a/Sources/JNaturalKorean/JNaturalKorean.swift
+++ b/Sources/JNaturalKorean/JNaturalKorean.swift
@@ -35,7 +35,9 @@ open class JNaturalKorean {
             return (word.isKindOf받침 ? "이" : "가")
         } else if word.isEndWithNumber {
             return (word.isKineOf받침Number ? "이" : "가")
-        }else {
+        } else if word.isJapanese {
+            return (word.is일본어받침 ? "이" : "가")
+        } else {
             return ""
         }
     }
@@ -51,12 +53,18 @@ open class JNaturalKorean {
     // ex) - 그 프로그래머**는** 실력자 입니다.
     open class func get_은_는(word: String) -> String {
         if word.isHangul {
+            print("isHangule: \(word)")
             return (word.isThere종성 ? "은" : "는")
         } else if word.isEnglish {
+            print("isEnglish: \(word)")
             return (word.isKindOf받침 ? "은" : "는")
         } else if word.isEndWithNumber {
+            print("inEndWithNumber: \(word)")
             return (word.isKineOf받침Number ? "은" : "는")
-        }else {
+        } else if word.isJapanese {
+            print("is일본어")
+            return (word.is일본어받침 ? "은" : "는")
+        } else {
             return ""
         }
     }
@@ -77,7 +85,9 @@ open class JNaturalKorean {
             return (word.isKindOf받침 ? "을" : "를")
         } else if word.isEndWithNumber {
             return (word.isKineOf받침Number ? "을" : "를")
-        }else {
+        } else if word.isJapanese {
+            return (word.is일본어받침 ? "을" : "를")
+        } else {
             return ""
         }
     }
@@ -98,7 +108,9 @@ open class JNaturalKorean {
             return (word.isL ? "로" : (word.isKindOf받침 ? "으로" : "로"))
         } else if word.isEndWithNumber {
             return (word.isOne ? "로" : (word.isKineOf받침Number ? "으로" : "로"))
-        }else {
+        } else if word.isJapanese {
+            return (word.is일본어받침 ? "으로" : "로")
+        } else {
             return ""
         }
     }
@@ -118,7 +130,9 @@ open class JNaturalKorean {
             return (word.isKindOf받침 ? "아" : "야")
         } else if word.isEndWithNumber {
             return (word.isKineOf받침Number ? "아" : "야")
-        }else {
+        } else if word.isJapanese {
+            return (word.is일본어받침 ? "아" : "야")
+        } else {
             return ""
         }
     }
@@ -139,7 +153,9 @@ open class JNaturalKorean {
             return (word.isKindOf받침 ? "과" : "와")
         } else if word.isEndWithNumber {
             return (word.isKineOf받침Number ? "과" : "와")
-        }else {
+        } else if word.isJapanese {
+            return (word.is일본어받침 ? "과" : "와")
+        } else {
             return ""
         }
     }
@@ -227,6 +243,25 @@ extension String {
     fileprivate var isL: Bool {
         let value = Int((String(self.last!).unicodeScalars.first?.value)!)
         return (value == 76 || value == 108)
+    }
+}
+
+// MARK: - String+JNaturalKorean Private Utils for 일본어
+extension String {
+    fileprivate var isJapanese: Bool {
+        guard let lastUnicode = self.unicodeScalars.last else {
+            return false
+        }
+        let last = Int(lastUnicode.value)
+        return 12352 <= last && last <= 12799 // 12352~12447(히라가나), 12448~12799(가타가나)
+    }
+    
+    fileprivate var lastCharString: String {
+        return self.suffix(1).map { char in return String(char) }.reduce("", +)
+    }
+    
+    fileprivate var is일본어받침: Bool {
+        return (self.lastCharString == "ん") || (self.lastCharString == "ン")
     }
 }
 

--- a/Sources/JNaturalKorean/JNaturalKorean.swift
+++ b/Sources/JNaturalKorean/JNaturalKorean.swift
@@ -53,16 +53,12 @@ open class JNaturalKorean {
     // ex) - 그 프로그래머**는** 실력자 입니다.
     open class func get_은_는(word: String) -> String {
         if word.isHangul {
-            print("isHangule: \(word)")
             return (word.isThere종성 ? "은" : "는")
         } else if word.isEnglish {
-            print("isEnglish: \(word)")
             return (word.isKindOf받침 ? "은" : "는")
         } else if word.isEndWithNumber {
-            print("inEndWithNumber: \(word)")
             return (word.isKineOf받침Number ? "은" : "는")
         } else if word.isJapanese {
-            print("is일본어")
             return (word.is일본어받침 ? "은" : "는")
         } else {
             return ""

--- a/Tests/JNaturalKoreanTests/JNaturalKoreanTests.swift
+++ b/Tests/JNaturalKoreanTests/JNaturalKoreanTests.swift
@@ -67,6 +67,22 @@ final class JNaturalKoreanTests: XCTestCase {
         XCTAssertEqual("programmer".으로_로, "programmer로")
         XCTAssertEqual("programmer".아_야, "programmer야")
         XCTAssertEqual("programmer".와_과, "programmer와")
+        
+        // さくら 사쿠라
+        XCTAssertEqual("さくら".이_가, "さくら가")
+        XCTAssertEqual("さくら".은_는, "さくら는")
+        XCTAssertEqual("さくら".을_를, "さくら를")
+        XCTAssertEqual("さくら".으로_로, "さくら로")
+        XCTAssertEqual("さくら".아_야, "さくら야")
+        XCTAssertEqual("さくら".와_과, "さくら와")
+        
+        // キムさん 김 상
+        XCTAssertEqual("キムさん".이_가, "キムさん이")
+        XCTAssertEqual("キムさん".은_는, "キムさん은")
+        XCTAssertEqual("キムさん".을_를, "キムさん을")
+        XCTAssertEqual("キムさん".으로_로, "キムさん으로")
+        XCTAssertEqual("キムさん".아_야, "キムさん아")
+        XCTAssertEqual("キムさん".와_과, "キムさん과")
     }
 
     /// Returns path to the built products directory.


### PR DESCRIPTION
Add Japanese(Hiragana, Katakana) words case. In Japanese, only 2 letter ン, ん(ㄴ,ㅇ) were pronounced as Jongsung. This commit detects if this 2 letters were used  at the last place of word. 

영어의 받침 발음을 구분하여 조사를 붙이는 방법을 응용하여, 일본어 받침이 들어가는 단어를 구분하여 조사를 붙이도록 기능을 추가했습니다.
일본어에는 단어 마지막에서 받침으로 쓰이는 문자가 ン, ん 단 2개 존재합니다. 이 두 문자가 단어 마지막에 있는지 확인하여 알맞은 한국어 조사를 사용하도록 구현했습니다. 